### PR TITLE
Tailmon Bug Fixes

### DIFF
--- a/tailmon.sh
+++ b/tailmon.sh
@@ -21,7 +21,7 @@ export SCREENDIR="${HOME}/.screen"
 
 #Static Variables - please do not change
 version="1.3.5"
-beta=0                                                               # Beta indicator on/off
+beta=1                                                               # Beta indicator on/off
 track=0                                                              # Stable (0) / Beta (1) Track subscription
 apppath="/jffs/scripts/tailmon.sh"                                   # Static path to the app
 config="/jffs/addons/tailmon.d/tailmon.cfg"                          # Static path to the config file
@@ -54,7 +54,7 @@ args="--tun=userspace-networking --state=/opt/var/tailscaled.state --statedir=/o
 preargs="nohup"
 routes="$(nvram get lan_ipaddr | cut -d"." -f1-3).0/24"
 customcmdline=""
-advsetupbypass=0
+progresspromptactive=0                                             # Tracks the two-line monitoring prompt
 
 #AMTM Email Notification Variables
 readonly scriptFileName="${0##*/}"
@@ -236,10 +236,77 @@ preparebar()
   barchars=$(printf "%*s" "$1" | tr ' ' "$2")
 }
 
+# Read exactly one visible menu command followed by Enter.
+# Normal terminal echo and line editing remain available; pasted multi-character input is ignored.
+readmenucommand()
+{
+  key_press=""
+  menu_line_submitted=0
+  ttydev="$(tty 2>/dev/null)"
+
+  if [ -z "$ttydev" ] || [ "$ttydev" = "not a tty" ]; then
+    return 1
+  fi
+
+  if IFS= read -r -t 1 key_press < "$ttydev"; then
+    menu_line_submitted=1
+    [ "${#key_press}" -eq 1 ]
+    return $?
+  fi
+
+  key_press=""
+  return 1
+}
+
+# Keep the editable command prompt on its own line. Timer refreshes update only
+# the line above it, preserving terminal echo, cursor position and backspace editing.
+drawprogressprompt()
+{
+  local status_text="$1"
+  local input_text="$2"
+
+  if [ "$progresspromptactive" -ne 1 ]; then
+    printf "\033[2K\r%b\n\033[2K\r%s\033[2D" "$status_text" "$input_text"
+    progresspromptactive=1
+  else
+    # Save the current input cursor, redraw only the status line above, then restore it.
+    printf "\033[s\033[1A\033[2K\r%b\033[u" "$status_text"
+  fi
+}
+
+resetinvalidprogressinput()
+{
+  # A complete line was submitted, but it was not exactly one command character.
+  # read(1) has moved to the following line, so move back and restore a clean prompt.
+  printf "\033[1A\33[2K\r  [Key+Enter?  ]\033[2D"
+}
+
+# Discard characters typed or pasted while an interactive command owned the terminal.
+# This prevents an authentication URL, including an incomplete line with no Enter, from
+# being interpreted later as part of a setup-menu selection.
+drainpendingttyinput()
+{
+  local ttydev discarded_input
+
+  ttydev="$(tty 2>/dev/null)"
+  if [ -z "$ttydev" ] || [ "$ttydev" = "not a tty" ]; then
+    return 0
+  fi
+
+  # Read one character at a time so this also clears a partial pasted line that
+  # has not yet received Enter. The final one-second timeout confirms the queue
+  # is empty. BusyBox ash already supports this -n1 form elsewhere in TAILMON.
+  while IFS= read -r -n 1 -t 1 discarded_input < "$ttydev"; do
+    :
+  done
+}
+
 progressbaroverride()
 {
   insertspc=" "
   bypasswancheck=0
+
+  [ "$1" -eq 1 ] && progresspromptactive=0
 
   if [ $1 -eq -1 ]; then
     printf "\r  $barspaces\r"
@@ -257,15 +324,13 @@ progressbaroverride()
     if [ ! -z $6 ]; then AltNum=$6; else AltNum=$1; fi
 
     if [ "$5" == "Standard" ]; then
-      printf "  ${CWhite}${InvDkGray}$AltNum${4} / ${progr}%%${CClear} [${CGreen}e${CClear}=Exit] [Selection? ${InvGreen} ${CClear}${CGreen}]\r${CClear}" "$barchars" "$barspaces"
+      drawprogressprompt "  ${CWhite}${InvDkGray}$AltNum${4} / ${progr}%${CClear} [${CGreen}e${CClear}=Exit]${CClear}" "  [Key+Enter?  ]"
     fi
   fi
 
-  # Borrowed this wonderful keypress capturing mechanism from @Eibgrad... thank you! :)
-  #key_press=''; read -rsn1 -t 1 key_press < "$(tty 0>&2)"
-  key_press=''; read -rsn1 -t 1 key_press < "$(tty 0>&2 2>/dev/null || echo /dev/null)"
-
-  if [ $key_press ]; then
+  # Require one command character followed by Enter. Pasted text is ignored.
+  if readmenucommand; then
+      progresspromptactive=0
       case $key_press in
           [Aa]) vconfig;;
           [Cc]) vsetup;;
@@ -281,6 +346,8 @@ progressbaroverride()
           [Uu]) tsup;;
           *) timer=$timerloop;;
       esac
+  elif [ "$menu_line_submitted" -eq 1 ]; then
+      resetinvalidprogressinput
   fi
 }
 
@@ -288,6 +355,8 @@ progressbarpause()
 {
   insertspc=" "
   bypasswancheck=0
+
+  [ "$1" -eq 1 ] && progresspromptactive=0
 
   if [ "$1" -eq -1 ]
   then
@@ -308,20 +377,20 @@ progressbarpause()
 
     if [ "$5" = "Standard" ]
     then
-       printf "  ${CWhite}${InvDkGray}Continuing in $AltNum/5...${CClear} [${CGreen}s${CClear}=Setup] [${CGreen}e${CClear}=Exit] [Selection? ${InvGreen} ${CClear}${CGreen}]\r${CClear}" "$barchars" "$barspaces"
+       drawprogressprompt "  ${CWhite}${InvDkGray}Continuing in $AltNum/5...${CClear} [${CGreen}s${CClear}=Setup] [${CGreen}e${CClear}=Exit]${CClear}" "  [Key+Enter?  ]"
     fi
   fi
 
-  # Borrowed this wonderful keypress capturing mechanism from @Eibgrad... thank you! :)
-  #key_press=''; read -rsn1 -t 1 key_press < "$(tty 0>&2)"
-  key_press=''; read -rsn1 -t 1 key_press < "$(tty 0>&2 2>/dev/null || echo /dev/null)"
-
-  if [ $key_press ]
+  # Require one command character followed by Enter. Pasted text is ignored.
+  if readmenucommand
   then
+      progresspromptactive=0
       case $key_press in
           [Ss]) vsetup;;
           [Ee]) logoNMexit; echo -e "${CClear}\n"; exit 0;;
       esac
+  elif [ "$menu_line_submitted" -eq 1 ]; then
+      resetinvalidprogressinput
   fi
 }
 
@@ -330,7 +399,6 @@ progressbarpause()
 
 initialsetup()
 {
-    advsetupbypass=0
     clear
     echo -e "${InvGreen} ${InvDkGray}${CWhite} TAILMON Initial Setup                                                                 ${CClear}"
     echo -e "${InvGreen} ${CClear}"
@@ -361,11 +429,11 @@ initialsetup()
         expressinstall;;
 
         2)
-        echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: TAILMON Advanced Install initiated." >> $logfile
-        #exec sh /jffs/scripts/tailmon.sh -setup;;
-        advsetupbypass=1
-        vsetup;;
-        
+          echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: TAILMON Advanced Install initiated." >> "$logfile"
+          saveconfig
+          exec sh /jffs/scripts/tailmon.sh -setup
+          ;;
+
         [Ee]) echo -e "${CClear}"; echo ""; exit 0;;
       esac
 }
@@ -373,114 +441,200 @@ initialsetup()
 # -------------------------------------------------------------------------------------------------------------------------
 # Expressinstall script
 
+expressinstallfail()
+{
+  express_error="$1"
+
+  echo ""
+  echo -e "${CRed}ERROR: $express_error${CClear}"
+  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - ERROR: Express Install failed: $express_error" >> "$logfile"
+  echo ""
+  read -rsp $'Press any key to return to setup...\n' -n1 key
+
+  exec sh /jffs/scripts/tailmon.sh -setup
+  exit 1
+}
+
 expressinstall()
 {
   echo ""
   echo -e "Ready to Express Install Tailscale?"
   if promptyn "[y/n]: "
-    then
-      if [ -d "/opt" ]; then # Does entware exist? If yes proceed, if no error out.
-        echo ""
-        echo -e "\n${CGreen}Updating Entware Packages...${CClear}"
-        echo ""
-        opkg update
-        echo ""
-        echo -e "Installing Entware ${CGreen}CoreUtils-Timeout${CClear} Package...${CClear}"
-        echo ""
-        opkg install coreutils-timeout
-        echo ""
-        echo -e "Installing Entware ${CGreen}Screen${CClear} Package...${CClear}"
-        echo ""
-        opkg install screen
-        echo ""
-        echo -e "${CGreen}Installing Tailscale Package(s)...${CClear}"
-        echo ""
-        archker=$(opkg print-architecture | grep "armv7-2.6")
-        if [ -z "$archker" ]; then
-          opkg install tailscale
-        else
-          opkg install tailscale_nohf #install special tailscale package for arm7 kernel 2.6
-        fi
-        echo ""
-        echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale Entware package installed." >> $logfile
-      else
-        clear
-        echo -e "${CRed}ERROR: Entware was not found on this router...${CClear}"
-        echo -e "Please install Entware using the AMTM utility before proceeding..."
-        echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - ERROR: Entware was not found installed on router. Please investigate." >> $logfile
-        echo ""
-        read -rsp $'Press any key to continue...\n' -n1 key
-        exit 1
-      fi
-    else
+  then
+    if [ ! -d "/opt" ]; then
+      clear
+      echo -e "${CRed}ERROR: Entware was not found on this router...${CClear}"
+      echo -e "Please install Entware using the AMTM utility before proceeding..."
+      echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - ERROR: Entware was not found installed on router. Please investigate." >> "$logfile"
       echo ""
-      echo -e "${CClear}"
-      exit 0
+      read -rsp $'Press any key to continue...\n' -n1 key
+      exit 1
+    fi
+  else
+    echo ""
+    echo -e "${CClear}"
+    exit 0
   fi
-  
+
+  echo ""
+  echo -e "\n${CGreen}Updating Entware Packages...${CClear}"
+  echo ""
+  if ! opkg update; then
+    expressinstallfail "Unable to update the Entware package lists."
+  fi
+
+  echo ""
+  echo -e "Installing Entware ${CGreen}CoreUtils-Timeout${CClear} Package...${CClear}"
+  echo ""
+  if ! opkg install coreutils-timeout; then
+    expressinstallfail "Unable to install the Entware coreutils-timeout package."
+  fi
+
+  echo ""
+  echo -e "Installing Entware ${CGreen}Screen${CClear} Package...${CClear}"
+  echo ""
+  if ! opkg install screen; then
+    expressinstallfail "Unable to install the Entware screen package."
+  fi
+
+  echo ""
+  echo -e "${CGreen}Installing Tailscale Package(s)...${CClear}"
+  echo ""
+  archker=$(opkg print-architecture | grep "armv7-2.6")
+  if [ -z "$archker" ]; then
+    tspackage="tailscale"
+  else
+    tspackage="tailscale_nohf"
+  fi
+
+  if ! opkg install "$tspackage"; then
+    expressinstallfail "Unable to install the Entware $tspackage package."
+  fi
+
+  if [ ! -x "/opt/bin/tailscale" ] ||
+     [ ! -x "/opt/bin/tailscaled" ] ||
+     [ ! -f "/opt/etc/init.d/S06tailscaled" ]; then
+    expressinstallfail "The Tailscale binaries or service script were not installed correctly."
+  fi
+
+  echo ""
+  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale Entware package installed." >> "$logfile"
+
   echo -e "${CGreen}Updating Tailscale Binary to latest version..."
   echo ""
-  echo -e "Executing: tailscale update${CClear}"
+  echo -e "Executing: tailscale update --yes${CClear}"
   echo ""
-  tailscale update
+
+  tsversion_before="$(tailscale version 2>/dev/null | awk 'NR==1 {print $1}')"
+  tailscale update --yes
+  tsupdate_rc=$?
+  tsversion_after="$(tailscale version 2>/dev/null | awk 'NR==1 {print $1}')"
+
+  if [ -z "$tsversion_after" ]; then
+    expressinstallfail "The installed Tailscale version could not be verified after the update."
+  fi
+
+  if [ "$tsupdate_rc" -ne 0 ]; then
+    if [ "$tsversion_after" = "$tsversion_before" ]; then
+      expressinstallfail "The Tailscale binary update failed."
+    fi
+
+    # Tailscale may update both binaries successfully but return an error because
+    # this Entware service is not managed by systemd or a standard init.d service.
+    echo ""
+    echo -e "${CYellow}WARNING: tailscale update returned an error, but the binary changed from"
+    echo -e "v$tsversion_before to v$tsversion_after and was verified successfully.${CClear}"
+  fi
+
+  if [ ! -x "/opt/bin/tailscale" ] || [ ! -x "/opt/bin/tailscaled" ]; then
+    expressinstallfail "The updated Tailscale binaries are not executable."
+  fi
+
   echo ""
-  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale binary updated to latest available version." >> $logfile
-      
+  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale binary verified at version $tsversion_after." >> "$logfile"
+
   echo -e "${CGreen}Applying settings for Userspace mode of operation...${CClear}"
 
-    tsoperatingmode="Userspace"
-    precmd=""
-    args="--tun=userspace-networking --state=/opt/var/tailscaled.state --statedir=/opt/var/lib/tailscale"
-    preargs="nohup"
-    saveconfig
+  tsoperatingmode="Userspace"
+  precmd=""
+  args="--tun=userspace-networking --state=/opt/var/tailscaled.state --statedir=/opt/var/lib/tailscale"
+  preargs="nohup"
+  saveconfig
 
   echo ""
   echo -e "${CGreen}Applying settings to Tailscale service and connection...${CClear}"
 
-  if [ -f "/opt/bin/tailscale" ]; then
-    #make mods to the S06tailscaled service for Userspace mode
-    if [ "$tsoperatingmode" == "Userspace" ]; then
+  if ! sed -i "s/^ARGS=.*/ARGS=\"--tun=userspace-networking\ --state=\/opt\/var\/tailscaled.state\ --statedir=\/opt\/var\/lib\/tailscale\"/" "/opt/etc/init.d/S06tailscaled"; then
+    expressinstallfail "Unable to apply the Userspace ARGS setting to S06tailscaled."
+  fi
 
-      sed -i "s/^ARGS=.*/ARGS=\"--tun=userspace-networking\ --state=\/opt\/var\/tailscaled.state\ --statedir=\/opt\/var\/lib\/tailscale\"/" "/opt/etc/init.d/S06tailscaled"
-      sed -i "s/^PREARGS=.*/PREARGS=\"nohup\"/" "/opt/etc/init.d/S06tailscaled"
-      sed -i -e '/^PRECMD=/d' "/opt/etc/init.d/S06tailscaled"
-      echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Userspace Mode settings have been applied." >> $logfile
+  if ! sed -i "s/^PREARGS=.*/PREARGS=\"nohup\"/" "/opt/etc/init.d/S06tailscaled"; then
+    expressinstallfail "Unable to apply the Userspace PREARGS setting to S06tailscaled."
+  fi
 
-      #remove firewall-start entry if found
-      if [ -f /jffs/scripts/firewall-start ]; then
+  if ! sed -i -e '/^PRECMD=/d' "/opt/etc/init.d/S06tailscaled"; then
+    expressinstallfail "Unable to remove the PRECMD setting from S06tailscaled."
+  fi
 
-        if grep -q -F "if [ -x /opt/bin/tailscale ]; then tailscale down; tailscale up; fi" /jffs/scripts/firewall-start; then
-          sed -i -e '/tailscale down/d' /jffs/scripts/firewall-start
-        fi
+  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Userspace Mode settings have been applied." >> "$logfile"
 
-      fi
-    fi
-  else
-    echo ""
-    echo -e "${CRed}ERROR: Tailscale binary was not found. Please check Entware and router/drive for errors.${CClear}"
-    echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - ERROR: Tailscale binaries not found on router. Please investigate." >> $logfile
-    exit 1
+  # Remove the legacy firewall-start entry if found.
+  if [ -f "/jffs/scripts/firewall-start" ] &&
+     grep -q -F "if [ -x /opt/bin/tailscale ]; then tailscale down; tailscale up; fi" "/jffs/scripts/firewall-start"; then
+    sed -i -e '/tailscale down/d' "/jffs/scripts/firewall-start"
   fi
 
   echo ""
   echo -e "${CGreen}Starting Tailscale service...${CClear}"
   echo ""
-  /opt/etc/init.d/S06tailscaled start
-  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale Service started." >> $logfile
+  if ! /opt/etc/init.d/S06tailscaled start; then
+    expressinstallfail "The Tailscale service command failed to start."
+  fi
+
+  service_ready=0
+  service_wait=0
+  while [ "$service_wait" -lt 5 ]
+  do
+    sleep 1
+    if /opt/etc/init.d/S06tailscaled check >/dev/null 2>&1; then
+      service_ready=1
+      break
+    fi
+    service_wait=$((service_wait+1))
+  done
+
+  if [ "$service_ready" -ne 1 ]; then
+    expressinstallfail "tailscaled did not remain running after startup."
+  fi
+
+  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale Service started and verified." >> "$logfile"
 
   echo ""
   echo ""
   echo -e "${CGreen}Starting Tailscale connection...${CClear}"
   echo ""
-  echo -e "${CGreen}Please be prepared to copy and paste the link below into your browser, and connect this device"
-  echo -e "to your tailnet (Tailscale Network)${CClear}"
+  echo -e "${CGreen}Please copy the authentication link below into your browser and connect this device"
+  echo -e "to your tailnet. Do not paste the link back into the TAILMON terminal.${CClear}"
   echo ""
+
   advroutescmd="--advertise-routes=$routes"
-  if [ $sshenable -eq 1 ]; then sshcmd=" --ssh"; else sshcmd=""; fi
+  if [ "$sshenable" -eq 1 ]; then
+    sshcmd=" --ssh"
+  else
+    sshcmd=""
+  fi
+
   echo -e "${CGreen}Executing: tailscale up $advroutescmd$sshcmd${CClear}"
   echo ""
-  tailscale up $advroutescmd$sshcmd
-  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale Connection started." >> $logfile
+  if ! tailscale up $advroutescmd$sshcmd; then
+    expressinstallfail "The Tailscale connection did not start correctly."
+  fi
+
+  if ! tailscale status >/dev/null 2>&1; then
+    expressinstallfail "The Tailscale connection could not be verified after authentication."
+  fi
+
+  echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale Connection started and verified." >> "$logfile"
 
   echo ""
   echo ""
@@ -536,6 +690,11 @@ installts()
         read -rsp $'Press any key to continue...\n' -n1 key
         exit 1
       fi
+    else
+      echo ""
+      echo -e "${CClear}[Installation cancelled]"
+      sleep 1
+      return
   fi
   resettimer=1
   
@@ -544,11 +703,12 @@ installts()
   if promptyn "[y/n]: "
     then
       echo ""
-      echo -e "${CGreen}Updating Tailscale Binary"
+      echo -e "${CGreen}Updating Tailscale Binary${CClear}"
       echo ""
-      echo "Executing: tailscale update${CClear}"
+      echo -e "${CGreen}Executing: tailscale update${CClear}"
       echo ""
       tailscale update
+      echo -e "${CClear}"
       echo ""
       echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale binary updated to latest available version." >> $logfile
       echo ""
@@ -853,6 +1013,10 @@ tsup()
         fi
       fi
 
+      # `tailscale up` may leave pasted authentication text/newlines queued on the TTY.
+      # Drain that pending terminal input before returning to the setup menu.
+      drainpendingttyinput
+
       echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - INFO: Tailscale Connection started." >> $logfile
       resettimer=1
 }
@@ -1126,7 +1290,7 @@ autoupdate()
           printf "${CGreen}\r[Downloading New Tailscale Binary v$servertsver]\n"
           echo -e "${CClear}"
           sleep 1
-          tailscale update -yes
+          tailscale update --yes
           officialtsver=$?
           if [ $officialtsver -ne 0 ]
             then
@@ -2017,6 +2181,11 @@ while true; do
           break
 
         fi
+      else
+        echo ""
+        echo -e "${CClear}[Exiting]"
+        timer=$timerloop
+        break
       fi
     ;;
 
@@ -2180,7 +2349,7 @@ exitnodets()
   saveconfig
   timer=$timerloop
 
-  if [ $exitnode -ne $oldexitnode ]; then
+  if [ -f "/opt/bin/tailscale" ] && [ "$exitnode" -ne "$oldexitnode" ]; then
     echo ""
     echo -e "\nChanging exit node configuration options will require a restart of Tailscale. Restart now?"
     if promptyn "[y/n]: "
@@ -2264,7 +2433,7 @@ advroutests()
   saveconfig
   timer=$timerloop
 
-  if [ $advroutes -ne $oldadvroutes ] || [ "$routes" != "$oldroutes" ]; then
+  if [ -f "/opt/bin/tailscale" ] && { [ "$advroutes" -ne "$oldadvroutes" ] || [ "$routes" != "$oldroutes" ]; }; then
     echo ""
     echo -e "\nChanging advertised routes configuration options will require a restart of Tailscale. Restart now?"
     if promptyn "[y/n]: "
@@ -2318,7 +2487,7 @@ accroutests()
   saveconfig
   timer=$timerloop
 
-  if [ $accroutes -ne $oldaccroutes ]; then
+  if [ -f "/opt/bin/tailscale" ] && [ "$accroutes" -ne "$oldaccroutes" ]; then
     echo ""
     echo -e "\nChanging routing configuration options will require a restart of Tailscale. Restart now?"
     if promptyn "[y/n]: "
@@ -2374,7 +2543,7 @@ sshts()
   saveconfig
   timer=$timerloop
 
-  if [ $sshenable -ne $oldsshenable ]; then
+  if [ -f "/opt/bin/tailscale" ] && [ "$sshenable" -ne "$oldsshenable" ]; then
     echo ""
     echo -e "\nChanging the SSH setting will require a restart of Tailscale. Restart now?"
     if promptyn "[y/n]: "
@@ -2916,12 +3085,10 @@ vsetup()
   fi
 
   # Grab the TAILMON config file and read it in
-  if [ $advsetupbypass -eq 0 ]; then
-    if [ -f $config ]; then
-      source $config
-    else
-      initialsetup
-    fi
+  if [ -f $config ]; then
+    source $config
+  else
+    initialsetup
   fi
 
   while true; do
@@ -3041,22 +3208,22 @@ vsetup()
 
         2) uninstallts;;
 
-        3) if [ -f "/opt/bin/tailscale" ]; then operatingmode; fi;;
+        3) operatingmode;;
 
         4) if [ "$tsoperatingmode" != "Custom" ]; then
-             if [ -f "/opt/bin/tailscale" ]; then exitnodets; fi
+             exitnodets
            fi ;;
 
         5) if [ "$tsoperatingmode" != "Custom" ]; then
-             if [ -f "/opt/bin/tailscale" ]; then advroutests; fi
+             advroutests
            fi ;;
 
         6) if [ "$tsoperatingmode" != "Custom" ]; then
-             if [ -f "/opt/bin/tailscale" ]; then accroutests; fi
+             accroutests
            fi ;;
 
         7) if [ "$tsoperatingmode" != "Custom" ]; then
-             if [ -f "/opt/bin/tailscale" ]; then sshts; fi
+             sshts
            fi ;;
 
         8) installdependencies;;
@@ -3067,7 +3234,7 @@ vsetup()
 
         11) vuninstall;;
 
-        [Ee]) echo ""; timer=$timerloop; break;;
+        [Ee]) echo -e "${CClear}"; timer=$timerloop; break;;
 
       esac
   done
@@ -4111,34 +4278,15 @@ while true; do
   fi
 
   #Determine if Tailscale service is down
-  if [ $tsinstalled -eq 1 ] && [ $keepalive -eq 1 ]; then
-    if [ $tsservice -ne 0 ]; then
-      printf "\33[2K\r"
-      printf "${CGreen}\r[Tailscale Service appears dead]"
-      echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - ERROR: Tailscale Service appears dead." >> $logfile
-      sleep 1
+  if [ "$tsinstalled" -eq 1 ] &&
+     [ "$keepalive" -eq 1 ] &&
+     [ "$tsstatus" -ne 0 ]; then
 
-      tsdown
-      stopts
-      startts
-      tsup
-
-      resettimer=1
-      echo ""
-      sendmessage 1 "Tailscale Service Restarted"
-
-      exec sh /jffs/scripts/tailmon.sh -noswitch
-
-    fi
-  fi
-
-  #Determine if Tailscale status is producing an error
-  if [ $tsstatus -ne 0 ]; then
     printf "\33[2K\r"
     printf "${CGreen}\r[Tailscale Status producing errors...Restarting services]"
-    echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - ERROR: Tailscale Status producing errors. Restarting services." >> $logfile
-    sleep 1
+    echo -e "$(date +'%b %d %Y %X') $($timeoutcmd$timeoutsec nvram get lan_hostname) TAILMON[$$] - ERROR: Tailscale Status producing errors. Restarting services." >> "$logfile"
 
+    sleep 1
     tsdown
     stopts
     startts


### PR DESCRIPTION
-Advanced options 3–7 did nothing before installation 
-Express Install could falsely report success
-Express Install did not verify service startup
-Express Install did not verify connection startup 
-Keep Alive disabled still restarted Tailscale
-Pasted text could trigger L and open Nano
-Monitoring input was invisible while the loop was refreshing 
-Pasted authentication text could contaminate the next menu selection